### PR TITLE
Fix GitHub Actions deprecated actions and resolve version tag conflict

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,8 +17,8 @@
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <version.final>1.2.8</version.final>
-        <version.dev>1.2.9-SNAPSHOT</version.dev>
+        <version.final>1.2.9</version.final>
+        <version.dev>1.2.10-SNAPSHOT</version.dev>
     </properties>
 
     <description>Fun Project :: A Console App


### PR DESCRIPTION
## Hotfix: GitHub Actions and Version Release Issues

### Problem
- GitHub Actions were using deprecated actions (upload-artifact@v3, create-release@v1)
- Maven Release Plugin failed due to existing tag v1.2.8 conflict

### Solution
- ✅ Updated to modern GitHub Actions:
  - `upload-artifact@v4` and `download-artifact@v4`
  - `softprops/action-gh-release@v2` instead of deprecated create-release
- ✅ Fixed version properties:
  - `version.final`: 1.2.8 → 1.2.9 (resolves tag conflict)
  - `version.dev`: 1.2.9-SNAPSHOT → 1.2.10-SNAPSHOT (next dev cycle)

### Impact
- Enables successful v1.2.9 release
- Fixes CI/CD pipeline with modern GitHub Actions
- Resolves Maven Release Plugin tag conflict

### Testing
- All GitHub Actions workflows updated to use supported versions
- Version properties aligned with project version structure

This hotfix should be merged to main to trigger the v1.2.9 release process.