### PR TITLE
Fix Mockito self-attaching warning by configuring agent in Surefire plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -281,6 +281,11 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.5.1</version>
+                <configuration>
+                    <argLine>
+                        -javaagent:${settings.localRepository}/org/mockito/mockito-core/5.14.2/mockito-core-5.14.2.jar
+                    </argLine>
+                </configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
## 🎯 **Problem Resolved**

Fixed the Mockito deprecation warning that appears during test execution:
```
Mockito is currently self-attaching to enable the inline-mock-maker. 
This will no longer work in future releases of the JDK. 
Please add Mockito as an agent to your build what is described in Mockito's documentation: 
https://javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/Mockito.html#0.3
```

## 🔧 **Solution Implemented**

### **Configuration Changes**
- **Modified**: `pom.xml` - Enhanced `maven-surefire-plugin` configuration
- **Added**: `-javaagent` parameter pointing to Mockito core JAR
- **Target**: `${settings.localRepository}/org/mockito/mockito-core/5.14.2/mockito-core-5.14.2.jar`

### **Technical Details**
```xml
<plugin>
    <groupId>org.apache.maven.plugins</groupId>
    <artifactId>maven-surefire-plugin</artifactId>
    <version>3.5.1</version>
    <configuration>
        <argLine>
            -javaagent:${settings.localRepository}/org/mockito/mockito-core/5.14.2/mockito-core-5.14.2.jar
        </argLine>
    </configuration>
</plugin>
```

## ✅ **Verification Results**

### **Before Fix**
```
❌ Mockito is currently self-attaching to enable the inline-mock-maker
❌ WARNING: A Java agent has been loaded dynamically
❌ WARNING: Dynamic loading of agents will be disallowed by default in a future release
```

### **After Fix**
```
✅ All tests pass without Mockito warnings
✅ No dynamic agent loading warnings
✅ Clean test execution output
✅ Full compatibility with future JDK releases
```

## 🚀 **Benefits**

- **Future-Proof**: Resolves upcoming JDK compatibility issues
- **Clean Output**: Eliminates deprecation warnings during test execution
- **Standards Compliance**: Follows Mockito's official documentation recommendations
- **Zero Impact**: No functional changes - all existing tests continue to pass
- **Maintainability**: Proper agent configuration for long-term project health

## 📋 **Testing**

- ✅ All existing unit tests pass
- ✅ No regression in functionality
- ✅ Mockito mocking continues to work as expected
- ✅ Build process remains unchanged
- ✅ Compatible with current Java 21 setup

## 🔗 **References**

- [Mockito Documentation](https://javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/Mockito.html#0.3)
- [Maven Surefire Plugin Documentation](https://maven.apache.org/surefire/maven-surefire-plugin/)

**Ready for merge** - This is a straightforward configuration fix with no breaking changes.